### PR TITLE
Fix headings.

### DIFF
--- a/_posts/2015-06-29-https-self-hosted-windows.markdown
+++ b/_posts/2015-06-29-https-self-hosted-windows.markdown
@@ -16,10 +16,10 @@ tags:
 comments: true
 ---
 
-##What's the problem?##
+## What's the problem? ##
 Setting up a web application to be served on HTTPS using IIS is quite easy. IIS takes care of most of the "ugly" details like managing the certificates (even creating a self signed one) and creating the binding to use it. But what if you are self hosting your web server outside of IIS? In that case, you have to understand a bit more to get things working.
 
-##Long story short##
+## Long story short ##
 If all you want is to quickly get the job done without knowing too much, scroll [down](#recap) for a quick run down of the things you need to do to setup HTTPS for a self hosted web server.
 
 Assumptions:
@@ -32,7 +32,7 @@ Assumptions:
 
 If any of the assumptions above does not hold for you, reading the long story might be more useful to you.
 
-##Short story long##
+## Short story long ##
 
 I'm not a security guy but from time to time i am required to perform some SSL related acrobatics to get something done. Let's face it, developers don't like SSL, it only complicates things for them and since its not an everyday activity i find myslef always relearning stuff i already foregot.
 
@@ -48,7 +48,7 @@ Self hosting web stacks (as in, not on IIS) has become a wide spread practice an
 
 Are done against the OS directly so, more pain.
 
-###Shortest passage on SSL I could write###
+### Shortest passage on SSL I could write ###
 
 *Disclaimer - This is going to be extremely simplistic, if you know your SSL stuff, don't hurt yourself by reading this part.*
 
@@ -61,13 +61,13 @@ The certificates bind some name to a public key and with some scheme called PKI 
 If the above is too much, just know that servers have a certificate that validates they are who they clame they are. And this certificate must be presented to the client.  
 The server can use the ceritificate only if it posseses something that is called *private key* which should be kept securely on the server and not shared with any client. This private key allows the server to decrypt things that were encrypted with the public key.
 
-####The chain of trust - CA's###
+#### The chain of trust - CA's ###
 
 Certificates represent trust, You trust a certificate a server presented to you because you (or actually your OS) trusts the one who signed that certificate. Thus, a chain of trust. The roots of that chains are called Certificate Authorities (CA's) and they also idnetify themselves with certificates. These certificates are already bundled with your OS and so you trust them. When a certificate is presented to a client, it has to follow the chain of trust up until either one of the signing certificates is already trusted by him or the root is declared as untrusted and so does the entire chain.
 
 When you purchase a certificate for you domain, you pay for one of those CA's to sign the certificate for you (directly or indirectly) and vouch for your identity. They usually require some prrof of your authenticity before signing your certificate. In case of a domain name, you would have to prove you actually own that domain.
 
-###Shortest passage on HTTPS I could write###
+### Shortest passage on HTTPS I could write ###
 
 *Disclaimer - This is going to be extremely simplistic, if you know your HTTPS stuff, don't hurt yourself by reading this part.*
 
@@ -77,7 +77,7 @@ Now, when a client tries to open an HTTPS connection to a server, it uses it's D
 
 For example, if a client opens up a a connection to `www.lovelydomain.com` the certificate should state that the owner is `www.lovelydomain.com`. (or also `*.lovelydomain.com` in case of a wildcard sub domain certificate)
 
-###A mental view of the windows stack###
+### A mental view of the windows stack ###
 
 If you are like me, a mental vision of the moving parts is very helpful in understading why we need to do things and against what. This also helps in debugging problems and working around situations where the step-by-step guide is not applicable. I find this invaluable and so here is my mental view of HTTP on windows.
 
@@ -91,7 +91,7 @@ Also, HTTP.sys does not just allow anyone to listen on anything and a security m
 
 [http_server_api]: https://msdn.microsoft.com/en-us/library/windows/desktop/aa364510(v=vs.85).aspx
 
-###Certificates and Windows Certificate Stores###
+### Certificates and Windows Certificate Stores ###
 
 Certificates are a digital entity, they can be stored in files while moving them around, in memory or in any other digital form. Windows provides the concept of a *certificate store* where certificates live. Many frameworks and applications running on windows use that store as a home for the certificates they use, this includes IIS and HTTP.sys. (And also .net WCF if you care)
 
@@ -107,7 +107,7 @@ Note - There are other file formats like `.pem`,`.crt`,`.cer` which can be used 
 
 [sslshopper]: https://www.sslshopper.com/ssl-converter.html
 
-####Importing a .pfx file into the certificate store####
+#### Importing a .pfx file into the certificate store ####
 
 We import the certificates into the LocalMachine location at the MY store.
 
@@ -124,7 +124,7 @@ You can look at the certificate you imported or also import using the windows ce
 
 [cert_mmc_snapin]: https://msdn.microsoft.com/en-us/library/ms788967(v=vs.110).aspx
 
-####Self-Signed certificates####
+#### Self-Signed certificates ####
 
 For development purposes, you can skip the purcahse of a certificate from a trusted CA and just sign your own. Of course, it would not be trusted by clients but you canlive with that as long as you control **both** the client and the server.
 
@@ -141,7 +141,7 @@ Another benefit in using `New-SelfSignedCertificate` is the support for SAN - bu
 [New-SelfSignedCertificate]: https://technet.microsoft.com/en-us/library/hh848633(v=wps.630).aspx
 [makecert]: https://msdn.microsoft.com/en-us/library/bfsktky3(v=vs.110).aspx
 
-###Managing HTTP.sys using Netsh###
+### Managing HTTP.sys using Netsh ###
 
 HTTP.sys provides an API for software developers while Windows provides some tools that wrap around that API for easier administration (and monitoring).  
 You might have came across the old HttpCfg.exe tool which is obsolete since Windows Vista / Server 2008.
@@ -150,7 +150,7 @@ The only tool you need to know today is Netsh which is sort of a swiss-army knif
 
 [netsh]: https://msdn.microsoft.com/en-us/library/windows/desktop/cc307236(v=vs.85).aspx
 
-###HTTP.sys SSL bindings###
+### HTTP.sys SSL bindings ###
 
 SSL bindings are the way an ip is bound to a port using a specific certificate. You can only bind one certificate for each combination of IP and port.
 
@@ -184,12 +184,12 @@ Once done, every connection attempt to that IP+Port combination would be answere
 
 **Note:** Certificates must be imported with a private key to be valid for this usage.
 
-###Listening on the HTTPS address###
+### Listening on the HTTPS address ###
 
 Eventually, your web server would have to tell HTTP.sys it wants to listen to HTTP communication on a specific URL path. Every framework has it's own way to configure that and in self hosted .Net application it is done by the HTTPListener class. 
 When specifying the URL to listen on make sure you specify `https` as the scheme part and the port the binding is on unless it's 443 which is the default anyway.
 
-###<a name="acls"></a>Securing who can listen - URL ACLs###
+### <a name="acls"></a>Securing who can listen - URL ACLs ###
 
 This is a somewhat advanced topic, but suffice to say the process who wishes to listen on a URL must have permission to do so. Controlling this permissions can also be done using netsh and if you done everything right but still cannot reach you application - this is a good place to look for answers.
 
@@ -201,15 +201,15 @@ I have been using [this great article][Demystify-http-sys-with-HttpSysManager] t
 
 [Demystify-http-sys-with-HttpSysManager]: http://www.codeproject.com/Articles/437733/Demystify-http-sys-with-HttpSysManager
 
-##<a name="recap"></a>Quick Recap - Configuration Steps##
+## <a name="recap"></a>Quick Recap - Configuration Steps ##
 
 These steps are required to configure an SSL binding for a self hosted OWIN web application on Windows Server 2012.  
 It relies on powershell and the fact that the operations are performed as an admin.
 
-###Get a Certificate###
+### Get a Certificate ###
 Get your certificate file (which should include also the private key) on the server. For example, this could be a file with the `.pfx` suffix.
 
-###Import the certificate to the windows certificate store###
+### Import the certificate to the windows certificate store ###
 Add the certificate file to the windows Local Machine / MY store. One way of doing that would be using powershell:
 
 {% highlight powershell %}
@@ -217,7 +217,7 @@ $certpwd = ConvertTo-SecureString -String "123456" -Force –AsPlainText
 Import-PfxCertificate –FilePath C:\temp\livepbt_cert.pfx cert:\localMachine\my -Password $certpwd
 {% endhighlight %}
 
-###List the certificates to find out the certificate hash##
+### List the certificates to find out the certificate hash ##
 Each certificate has a hash identifying it. This is required for the next step.
 From within Powershell run:
 `dir cert:\localmachine\my`
@@ -234,7 +234,7 @@ The output would look something like this:
 
 Copy the `Thumbprint` out, it would be used on the next step.
 
-###Create the https binding in http.sys using netsh###
+### Create the https binding in http.sys using netsh ###
 Using the following powershell code.
 
 {% highlight powershell %}
@@ -249,7 +249,7 @@ A valid output would state that the certificate was added and the binding create
 
 `SSL Certificate successfully added`
 
-###Setup your web server to serve HTTPS###
+### Setup your web server to serve HTTPS ###
 Different web hosting server/frameworks would have different API's to do that. As an example, this is how you would do it for an OWIN self hosted asp.net WEB API application:
 
 {% highlight c# %}
@@ -258,7 +258,7 @@ Different web hosting server/frameworks would have different API's to do that. A
 
 Usually, providing the `https` scheme as part of the application base url directs the framework to bind using SSL on the 443 default port.
 
-##What i did not cover##
+## What i did not cover ##
 
 - **Wildcard certificates /SAN** - The usage of a certificate to secure any possible subdomain is an economical choice if many subdomains are used, some limitations apply though. I did not cover the usage of these types of certificates.
 - **Trusting self signed certificates** - On a client you control, you can force the OS to trust your self signed certificates. I did not cover how to do that and the benefits of this method.

--- a/_posts/2015-07-25-attending_idesigns_master_classes.markdown
+++ b/_posts/2015-07-25-attending_idesigns_master_classes.markdown
@@ -15,7 +15,7 @@ tags:
 comments: true
 ---
 
-##Learning Hurts##
+## Learning Hurts ##
 
 > "The more I learn, the more I realize [how much] I don’t know." A. Einstein
 
@@ -23,7 +23,7 @@ I recently realized how I can tell the difference between a normal learning expe
 I had two recent experiences like that, both were [IDesign][idesign] classes, both were given by [Juval Löwy][lowy].
 
 
-##The Elusive Software Architect##
+## The Elusive Software Architect ##
 
 Being a software developer by profession and a problem solver by passion, I grew up into doing what I do today. Things mostly came naturally - that was, apparently, a big mistake.
 
@@ -42,7 +42,7 @@ Let me summarize it freely, most of us are lazy, trusting too much in the hands 
 
 The accidental reason I took the AMC was the presense of the word "Architect" in its name. The reason you should take it is to learn the truth about yourself and the profession you are in. Unless, you would not want to face the pain in realizing that truth.
 
-##The IKEA allegory##
+## The IKEA allegory ##
 
 Juval mentions IKEA furniture once in a while, would you buy such a furniture without its assembly manual? Do you imagine creating such assembly manual regardless of the design of the furniture itself? So many things could go wrong if you separate the two. Think impossibly complex furniture no one could ever build, or a construction process leaving out a large chunk of the furniture.
 
@@ -55,7 +55,7 @@ That duality, the design of the system and the design of the construction plan f
 
 Attending the next class was an even deeper disruption to what I believed was true.
 
-##Measure Thrice, Check Twice and Cut Once##
+## Measure Thrice, Check Twice and Cut Once ##
 
 The "Project Design Master Class" (PDMC) is an unremarkable name for a class that hides in my opinion an even larger boon than the AMC does. So unremarkable in fact, that before, during and after taking the class I could not explain in a sentence to anyone who asked what it was about without a feeling I am leaving something out. I usually mumbled something like "It's about planning, and projects, but for software, but not only, and in a surprising way..." but usually they dosed off and lost interest anyway after they heard the word "planning".
 
@@ -69,7 +69,7 @@ These efforts payoff even when the design process clearly indicates the project 
 
 Perhaps all the above is natural to you, it sure wasn't for me. But the level of attention to details, the sheer confidence and reliance on good engineering when designing the project is an eye-opener, no less. Juval mitigates real concerns with real tools. Down to the finer points of how best to present the plans to the decision makers allowing them to choose only good options. (or actually preventing them from making bad ones)
 
-##And a Show It Is##
+## And a Show It Is ##
 
 Juval is known to appreciate the scholars of old. He is relying and borrowing from other fields and aspects of life to better understand and explain our industry. While standing on the shoulders of giants is good, imagine the benefits of a giant standing on these shoulders. This post is not about Juval, but for lack of a better place I would like to give my personal point of view on the person behind IDesign.
 
@@ -77,7 +77,7 @@ Juval is sharp, and using his own terms, he "get's it". His analytic skills comb
 
 Attending the class, on top of what I said before, was a great show. Juval is a top presenter, and clearly enjoys what he is doing.
 
-##LEGO and Entropy##
+## LEGO and Entropy ##
 
 Since I was a young child I remember always comparing processes to LEGO. Specifically to either building a large dome from many LEGO bricks or smashing that same dome back to the pile of bricks it was created from.  This was my intuitive way of understanding entropy, and my practical way of telling the difference between applying force to organize something (against the universe) and applying force to disorganize something (with the universe). Things that go with the universe would go there anyway eventually. The mind of a child, go figure (pun intended).
 
@@ -86,7 +86,7 @@ Since I was a young child I remember always comparing processes to LEGO. Specifi
 I understand that building software goes against the universe, and as such, it is a process you need to apply force to. That force translates to the construction and the design of the construction. I understand that as well, but still not sure I am up to the task.  
 As I told someone I appreciate lately, once I will be standing on the other end of a successfully run software project, I will know. Up until then, it's all theory, and it's on me to prove it.
 
-##What about You?##
+## What about You? ##
 
 If you also sense something is wrong, gambling your way in and out of projects, could not fully grok the affects of the efforts you or your team are making, I urge you to go and take one of the classes. Either one would be enough to give you a glimpse of where the true problems are. The rest will be up to you, the same way it is up to me now.
 


### PR DESCRIPTION
Fixes #2.

The difference between the posts with messed-up headings and working ones seems to be that the latter have spaces between the `#`s and the text. This adds some to the posts with broken headings.

I couldn't test this locally since jekyll on my machine didn't mess up in the same way, but it seems to work in the GitHub preview.